### PR TITLE
Added the min_temp and max_temp configuration

### DIFF
--- a/custom_components/generic_water_heater/__init__.py
+++ b/custom_components/generic_water_heater/__init__.py
@@ -16,6 +16,8 @@ CONF_HEATER = "heater_switch"
 CONF_SENSOR = "temperature_sensor"
 CONF_TARGET_TEMP = "target_temperature"
 CONF_TEMP_DELTA = "delta_temperature"
+CONF_TEMP_MIN = "min_temp"
+CONF_TEMP_MAX = "max_temp"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -27,6 +29,8 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Required(CONF_SENSOR): cv.entity_id,
                         vol.Optional(CONF_TEMP_DELTA): vol.Coerce(float),
                         vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
+                        vol.Optional(CONF_TEMP_MIN): vol.Coerce(float),
+                        vol.Optional(CONF_TEMP_MAX): vol.Coerce(float),
                     }
                 )
             }

--- a/custom_components/generic_water_heater/water_heater.py
+++ b/custom_components/generic_water_heater/water_heater.py
@@ -21,7 +21,7 @@ from homeassistant.core import DOMAIN as HA_DOMAIN, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from . import CONF_HEATER, CONF_SENSOR, CONF_TARGET_TEMP, CONF_TEMP_DELTA
+from . import CONF_HEATER, CONF_SENSOR, CONF_TARGET_TEMP, CONF_TEMP_DELTA, CONF_TEMP_MIN, CONF_TEMP_MAX
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,11 +41,13 @@ async def async_setup_platform(
         sensor_entity_id = config[CONF_SENSOR]
         target_temp = config.get(CONF_TARGET_TEMP)
         temp_delta = config.get(CONF_TEMP_DELTA)
+        min_temp = config.get(CONF_TEMP_MIN)
+        max_temp = config.get(CONF_TEMP_MAX)
         unit = hass.config.units.temperature_unit
 
         entities.append(
             GenericWaterHeater(
-                name, heater_entity_id, sensor_entity_id, target_temp, temp_delta, unit
+                name, heater_entity_id, sensor_entity_id, target_temp, temp_delta, min_temp, max_temp, unit
             )
         )
 
@@ -56,7 +58,7 @@ class GenericWaterHeater(WaterHeaterEntity, RestoreEntity):
     """Representation of a generic water_heater device."""
 
     def __init__(
-        self, name, heater_entity_id, sensor_entity_id, target_temp, temp_delta, unit
+        self, name, heater_entity_id, sensor_entity_id, target_temp, temp_delta, min_temp, max_temp, unit
     ):
         """Initialize the water_heater device."""
         self._attr_name = name
@@ -65,6 +67,8 @@ class GenericWaterHeater(WaterHeaterEntity, RestoreEntity):
         self._support_flags = SUPPORT_FLAGS_HEATER
         self._target_temperature = target_temp
         self._temperature_delta = temp_delta
+        self._min_temp = min_temp
+        self._max_temp = max_temp
         self._unit_of_measurement = unit
         self._current_operation = STATE_ON
         self._current_temperature = None
@@ -105,6 +109,7 @@ class GenericWaterHeater(WaterHeaterEntity, RestoreEntity):
         """Return the list of available operation modes."""
         return self._operation_list
 
+    @property
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
         self._target_temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/custom_components/generic_water_heater/water_heater.py
+++ b/custom_components/generic_water_heater/water_heater.py
@@ -4,6 +4,8 @@ import logging
 from homeassistant.components.water_heater import (
     SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE,
+    DEFAULT_MIN_TEMP,
+    DEFAULT_MAX_TEMP,
     WaterHeaterEntity,
 )
 from homeassistant.const import (
@@ -16,10 +18,12 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.temperature import convert
 
 from . import CONF_HEATER, CONF_SENSOR, CONF_TARGET_TEMP, CONF_TEMP_DELTA, CONF_TEMP_MIN, CONF_TEMP_MAX
 
@@ -110,6 +114,21 @@ class GenericWaterHeater(WaterHeaterEntity, RestoreEntity):
         return self._operation_list
 
     @property
+    def min_temp(self):
+        """Return the minimum targetable temperature."""
+        """If the min temperature is not set on the config, returns the HA default for Water Heaters."""
+        if not self._min_temp:
+            self._min_temp = convert(DEFAULT_MIN_TEMP, TEMP_FAHRENHEIT, self._unit_of_measurement)
+        return self._min_temp
+
+    @property
+    def max_temp(self):
+        """Return the maximum targetable temperature."""
+        """If the max temperature is not set on the config, returns the HA default for Water Heaters."""
+        if not self._max_temp:
+            self._max_temp = convert(DEFAULT_MAX_TEMP, TEMP_FAHRENHEIT, self._unit_of_measurement)
+        return self._max_temp
+
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
         self._target_temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/custom_components/generic_water_heater/water_heater.py
+++ b/custom_components/generic_water_heater/water_heater.py
@@ -23,7 +23,11 @@ from homeassistant.const import (
 from homeassistant.core import DOMAIN as HA_DOMAIN, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util.temperature import convert
+
+try:
+    from homeassistant.util.unit_conversion import TemperatureConverter as convert
+except ImportError or ModuleNotFoundError:
+    from homeassistant.util.temperature import convert as convert
 
 from . import CONF_HEATER, CONF_SENSOR, CONF_TARGET_TEMP, CONF_TEMP_DELTA, CONF_TEMP_MIN, CONF_TEMP_MAX
 


### PR DESCRIPTION
Since the min_temp and max_temp values were not set on this component, it defaulted to the Water Heater component from HA (min: 110F max: 140F).

I added the possibility for the user to set these variables, falling back to HA defaults if they're not included on the config.

To keep the component agnostic to the units of measurements, the TemperatureConverter() function from homeassistant/util/unit_conversion was used. This function was included on 2022.10 so older versions will use the convert() from homeassistant/util/temperature (This function will be removed from HA Core starting 2023.4).